### PR TITLE
refactor: Enhance album overlay functionality and improve UI responsi…

### DIFF
--- a/e2e/album-collage.spec.ts
+++ b/e2e/album-collage.spec.ts
@@ -183,6 +183,48 @@ test.describe("Render Mix collage", () => {
     expect(backgroundImage).toContain("linear-gradient");
   });
 
+  test("keeps long desktop tracklists scrollable with the player visible", async ({ page }) => {
+    await page.setViewportSize({ width: 1280, height: 600 });
+    await openBooklet(page);
+
+    const longestEpisode = await page.evaluate(() => {
+      const episodes = (globalThis as unknown as { episodes: BrowserEpisode[] }).episodes;
+      return episodes.reduce(
+        (longest, episode, index) => {
+          if (episode.tracks.length > longest.trackCount) {
+            return { index, trackCount: episode.tracks.length };
+          }
+
+          return longest;
+        },
+        { index: 0, trackCount: 0 }
+      );
+    });
+    await page.locator(`.album-tile[data-index="${longestEpisode.index}"]`).click();
+    await expect(page.locator("#mix-overlay")).toHaveAttribute("aria-hidden", "false");
+
+    const overlayMetrics = await page.evaluate(() => {
+      const tracks = document.getElementById("overlay-tracks");
+      const playerPanel = document.querySelector<HTMLElement>(".detail-player-panel");
+      const playerRect = playerPanel?.getBoundingClientRect();
+      if (tracks) tracks.scrollTop = 160;
+
+      return {
+        tracksClientHeight: tracks?.clientHeight,
+        tracksScrollHeight: tracks?.scrollHeight,
+        tracksScrollTop: tracks?.scrollTop,
+        playerBottom: playerRect?.bottom,
+        playerTop: playerRect?.top,
+        viewportHeight: window.innerHeight,
+      };
+    });
+
+    expect(overlayMetrics.tracksScrollHeight || 0).toBeGreaterThan(overlayMetrics.tracksClientHeight || 0);
+    expect(overlayMetrics.tracksScrollTop).toBe(160);
+    expect(overlayMetrics.playerTop || 0).toBeLessThan(overlayMetrics.viewportHeight);
+    expect(overlayMetrics.playerBottom || 0).toBeLessThanOrEqual(overlayMetrics.viewportHeight);
+  });
+
   test("navigates overlay albums and closes with Escape", async ({ page }) => {
     await openBooklet(page);
 

--- a/src/components/EpisodesList.astro
+++ b/src/components/EpisodesList.astro
@@ -51,7 +51,7 @@ const allEpisodes = Astro.props.allEpisodes ?? [];
 
 <section
   id="mix-overlay"
-  class="mix-detail pointer-events-none fixed inset-0 z-100 hidden flex-col overflow-hidden bg-(--background) text-(--foreground) opacity-0 transition-[opacity,transform] duration-280 ease-[cubic-bezier(0.16,1,0.3,1)] transform-[translateY(14px)_scale(0.985)] max-[700px]:overflow-y-auto"
+  class="mix-detail pointer-events-none fixed inset-0 z-100 overflow-hidden bg-(--background) text-(--foreground) opacity-0 transition-[opacity,transform] duration-280 ease-[cubic-bezier(0.16,1,0.3,1)] transform-[translateY(14px)_scale(0.985)] max-[700px]:overflow-y-auto"
   aria-hidden="true"
   role="dialog"
   aria-modal="true"
@@ -109,10 +109,10 @@ const allEpisodes = Astro.props.allEpisodes ?? [];
   </div>
 
   <div
-    class="mix-detail-body grid flex-1 grid-cols-[380px_minmax(0,1fr)] overflow-hidden max-[900px]:grid-cols-[minmax(260px,36vw)_minmax(0,1fr)] max-[700px]:block max-[700px]:overflow-visible"
+    class="mix-detail-body grid min-h-0 flex-1 grid-cols-[380px_minmax(0,1fr)] overflow-hidden max-[900px]:grid-cols-[minmax(260px,36vw)_minmax(0,1fr)] max-[700px]:block max-[700px]:overflow-visible"
   >
     <aside
-      class="mix-detail-left flex flex-col overflow-hidden border-r border-(--border) bg-[#0a0104] max-[700px]:overflow-visible max-[700px]:border-r-0"
+      class="mix-detail-left flex min-h-0 flex-col overflow-hidden border-r border-(--border) bg-[#0a0104] max-[700px]:overflow-visible max-[700px]:border-r-0"
     >
       <div class="detail-art-panel relative shrink-0">
         <img
@@ -126,11 +126,6 @@ const allEpisodes = Astro.props.allEpisodes ?? [];
       <div
         class="detail-art-caption shrink-0 border-b border-(--border) bg-[rgba(13,2,5,0.72)] p-5"
       >
-        <p
-          id="overlay-kicker"
-          class="mb-1.25 font-mono text-[9px] uppercase tracking-[0.16em] text-(--accent)"
-        >
-        </p>
         <h2
           id="overlay-title"
           class="text-xl font-bold leading-[1.1] tracking-[0.04em] text-(--foreground)"
@@ -176,7 +171,7 @@ const allEpisodes = Astro.props.allEpisodes ?? [];
       </div>
 
       <div
-        class="detail-description-panel flex-1 overflow-y-auto border-b border-(--border) px-5 py-4 max-[700px]:overflow-visible"
+        class="detail-description-panel min-h-0 flex-1 overflow-y-auto border-b border-(--border) px-5 py-4 max-[700px]:overflow-visible"
       >
         <p
           id="overlay-description"
@@ -201,7 +196,7 @@ const allEpisodes = Astro.props.allEpisodes ?? [];
 
     <section
       id="overlay-track-panel"
-      class="mix-detail-right flex flex-col overflow-hidden bg-bg bg-cover bg-center bg-no-repeat max-[700px]:overflow-visible"
+      class="mix-detail-right flex min-h-0 flex-col overflow-hidden bg-bg bg-cover bg-center bg-no-repeat max-[700px]:overflow-visible"
     >
       <div
         class="tracklist-heading flex shrink-0 items-center gap-2.5 border-b border-(--border) px-8 pb-3.5 pt-4.5 font-mono text-[9px] uppercase tracking-[0.16em] text-(--muted-foreground)"
@@ -227,7 +222,7 @@ const allEpisodes = Astro.props.allEpisodes ?? [];
         <span>Label</span>
         <span>Time</span>
       </div>
-      <div id="overlay-tracks" class="overlay-tracks flex-1 overflow-y-auto"></div>
+      <div id="overlay-tracks" class="overlay-tracks min-h-0 flex-1 overflow-y-auto"></div>
     </section>
   </div>
 </section>

--- a/src/scripts/app.ts
+++ b/src/scripts/app.ts
@@ -74,8 +74,6 @@ const initEnterButton = () => {
   }
 };
 
-const formatType = (type: string) => (type === "mykonos" ? "Mykonos Sessions" : "Aural Homework");
-
 const getEpisodeImage = (episode: Episode) => {
   return episode.image_cover || episode.image_bg || "/img/episode-bg/ahNotFound.png";
 };
@@ -121,7 +119,6 @@ const initAlbumOverlay = () => {
   const counter = document.getElementById("overlay-counter");
   const navTitle = document.getElementById("overlay-nav-title");
   const image = document.getElementById("overlay-image") as HTMLImageElement | null;
-  const kicker = document.getElementById("overlay-kicker");
   const title = document.getElementById("overlay-title");
   const date = document.getElementById("overlay-date");
   const location = document.getElementById("overlay-location");
@@ -142,7 +139,6 @@ const initAlbumOverlay = () => {
     !counter ||
     !navTitle ||
     !image ||
-    !kicker ||
     !title ||
     !date ||
     !location ||
@@ -173,7 +169,6 @@ const initAlbumOverlay = () => {
     currentIndex = index;
     image.src = getEpisodeImage(episode);
     image.alt = episode.title;
-    kicker.textContent = formatType(episode.type);
     title.textContent = episode.title;
     navTitle.textContent = episode.title;
     counter.textContent = `${index + 1} / ${window.episodes.length}`;

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -171,7 +171,13 @@ body.overlay-open {
   grid-template-columns: repeat(auto-fill, minmax(min(100%, var(--tile-min)), 1fr));
 }
 
+.mix-detail {
+  display: none;
+}
+
 .mix-detail.is-open {
+  display: flex;
+  flex-direction: column;
   opacity: 1;
   pointer-events: auto;
   transform: translateY(0) scale(1);
@@ -193,6 +199,68 @@ body.overlay-open {
 .detail-close:focus-visible {
   color: var(--accent);
   outline: none;
+}
+
+.detail-description-panel,
+.overlay-tracks {
+  scrollbar-color: rgba(196, 17, 42, 0.42) rgba(13, 2, 5, 0.42);
+  scrollbar-width: thin;
+}
+
+.detail-description-panel::-webkit-scrollbar,
+.overlay-tracks::-webkit-scrollbar {
+  width: 0.5rem;
+}
+
+.detail-description-panel::-webkit-scrollbar-track,
+.overlay-tracks::-webkit-scrollbar-track {
+  background: rgba(13, 2, 5, 0.42);
+}
+
+.detail-description-panel::-webkit-scrollbar-thumb,
+.overlay-tracks::-webkit-scrollbar-thumb {
+  border: 2px solid rgba(13, 2, 5, 0.42);
+  background: rgba(196, 17, 42, 0.38);
+}
+
+.detail-description-panel::-webkit-scrollbar-thumb:hover,
+.overlay-tracks::-webkit-scrollbar-thumb:hover {
+  background: rgba(196, 17, 42, 0.58);
+}
+
+@media (min-width: 701px) {
+  .detail-art-panel {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    background: #0a0104;
+  }
+
+  #overlay-image {
+    height: min(380px, 44vh);
+    object-fit: contain;
+  }
+}
+
+@media (min-width: 701px) and (max-height: 700px) {
+  #overlay-image {
+    height: min(300px, 30vh);
+  }
+
+  .detail-art-caption,
+  .detail-description-panel,
+  .detail-player-panel {
+    padding: 0.875rem 1.25rem;
+  }
+
+  .detail-meta-panel {
+    gap: 0.5rem;
+    padding: 0.75rem 1.25rem;
+  }
+
+  .detail-player-panel p {
+    margin-bottom: 0.5rem;
+  }
 }
 
 @keyframes fadeIn {


### PR DESCRIPTION
## Summary

Refines the album detail overlay so long desktop tracklists remain usable while the embedded Listen player stays visible, especially on shorter desktop viewports.

## Changes

- Constrains the overlay layout with bounded flex/grid scroll areas so the tracklist can scroll independently.
- Keeps the desktop cover art contained and compacts fixed left-panel spacing on short viewports to prevent the Listen panel from being pushed below the screen.
- Removes the redundant series subtitle above the mix title, freeing more room for the description.
- Adds themed scrollbars for the overlay description and tracklist panels so native scroll UI blends with the red/dark site palette.
- Adds Playwright regression coverage for the longest tracklist at a `1280x600` desktop viewport.

## Validation

- `npm run build`
- `npm run lint`
- `npm run typecheck`
- `bun run test:e2e -- --project=chromium e2e/album-collage.spec.ts --workers=1 --reporter=json -g "long desktop tracklists"`
