### PR TITLE
feat: add deep link functionality / episode page generation

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -37,7 +37,7 @@ jobs:
         run: bun run build
 
       - name: Upload artifact
-        uses: actions/upload-pages-artifact@v4
+        uses: actions/upload-pages-artifact@v5
         with:
           path: ./dist
 
@@ -50,4 +50,4 @@ jobs:
     steps:
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v4
+        uses: actions/deploy-pages@v5

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -18,10 +18,6 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/setup-node@v6
-        with:
-          node-version: 'lts/*'
-
       - name: Checkout
         uses: actions/checkout@v6
 
@@ -31,7 +27,7 @@ jobs:
           bun-version: latest
 
       - name: Install dependencies
-        run: bun install
+        run: bun ci
 
       - name: Build
         run: bun run build

--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -4,7 +4,7 @@ import tailwindcss from '@tailwindcss/vite';
 export default defineConfig({
   output: 'static',
   build: {
-    format: 'file'
+    format: 'directory'
   },
   vite: {
     plugins: [tailwindcss()]

--- a/bun.lock
+++ b/bun.lock
@@ -4,17 +4,14 @@
   "workspaces": {
     "": {
       "name": "invigilators",
-      "dependencies": {
-        "@astrojs/check": "^0.9.9",
-        "astro": "^6.4.6",
-        "typescript": "^6",
-      },
       "devDependencies": {
+        "@astrojs/check": "^0.9.9",
         "@playwright/test": "^1.61.0",
         "@tailwindcss/vite": "^4.3.1",
         "@types/node": "^25",
         "@typescript-eslint/eslint-plugin": "^8.61.1",
         "@typescript-eslint/parser": "^8.61.1",
+        "astro": "^6.4.8",
         "astro-eslint-parser": "^1.4.0",
         "eslint": "^10",
         "eslint-config-prettier": "^10",
@@ -23,6 +20,7 @@
         "prettier": "^3",
         "prettier-plugin-astro": "^0.14.1",
         "tailwindcss": "^4",
+        "typescript": "^6",
       },
     },
   },
@@ -32,7 +30,7 @@
   "packages": {
     "@astrojs/check": ["@astrojs/check@0.9.9", "", { "dependencies": { "@astrojs/language-server": "^2.16.7", "chokidar": "^4.0.3", "kleur": "^4.1.5", "yargs": "^17.7.2" }, "peerDependencies": { "typescript": "^5.0.0 || ^6.0.0" }, "bin": { "astro-check": "bin/astro-check.js" } }, "sha512-A5UW8uIuErLWEoRQvzgXpO1gTjUFtK8r7nU2Z7GewAMxUb7bPvpk11qaKKgxqXlHJWlAvaaxy+Xg28A6bmQ1Tg=="],
 
-    "@astrojs/compiler": ["@astrojs/compiler@2.13.1", "", {}, "sha512-f3FN83d2G/v32ipNClRKgYv30onQlMZX1vCeZMjPsMMPl1mDpmbl0+N5BYo4S/ofzqJyS5hvwacEo0CCVDn/Qg=="],
+    "@astrojs/compiler": ["@astrojs/compiler@4.0.0", "", {}, "sha512-eouss7G8ygdZqHuke033VMcVw5HTZUu+PXd/h06DGDUg/jt5btPYPqh66ENWw/mU78rBrf/oeC4oqoBwMtDMNA=="],
 
     "@astrojs/internal-helpers": ["@astrojs/internal-helpers@0.10.0", "", { "dependencies": { "@types/hast": "^3.0.4", "@types/mdast": "^4.0.4", "js-yaml": "^4.1.1", "picomatch": "^4.0.4", "retext-smartypants": "^6.2.0", "shiki": "^4.0.2", "smol-toml": "^1.6.0", "unified": "^11.0.5" } }, "sha512-Ry2R3VPeIN4uPCSA4xQc+e+vsJXkalKpEbDc07hV+a/o5Bs2N/s/uDcPJH/05L19DKh9tAy7e6JM3YZ6Cxfezw=="],
 
@@ -400,7 +398,7 @@
 
     "array-iterate": ["array-iterate@2.0.1", "", {}, "sha512-I1jXZMjAgCMmxT4qxXfPXa6SthSoE8h6gkSI9BGGNv8mP8G/v0blc+qFnZu6K42vTOiuME596QaLO0TP3Lk0xg=="],
 
-    "astro": ["astro@6.4.7", "", { "dependencies": { "@astrojs/compiler": "^4.0.0", "@astrojs/internal-helpers": "0.10.0", "@astrojs/markdown-remark": "7.2.0", "@astrojs/telemetry": "3.3.2", "@capsizecss/unpack": "^4.0.0", "@clack/prompts": "^1.1.0", "@oslojs/encoding": "^1.1.0", "@rollup/pluginutils": "^5.3.0", "aria-query": "^5.3.2", "axobject-query": "^4.1.0", "ci-info": "^4.4.0", "clsx": "^2.1.1", "common-ancestor-path": "^2.0.0", "cookie": "^1.1.1", "devalue": "^5.8.1", "diff": "^8.0.3", "dset": "^3.1.4", "es-module-lexer": "^2.0.0", "esbuild": "^0.27.3", "flattie": "^1.1.1", "fontace": "~0.4.1", "get-tsconfig": "5.0.0-beta.4", "github-slugger": "^2.0.0", "html-escaper": "3.0.3", "http-cache-semantics": "^4.2.0", "js-yaml": "^4.1.1", "jsonc-parser": "^3.3.1", "magic-string": "^0.30.21", "magicast": "^0.5.2", "mrmime": "^2.0.1", "neotraverse": "^0.6.18", "obug": "^2.1.1", "p-limit": "^7.3.0", "p-queue": "^9.1.0", "package-manager-detector": "^1.6.0", "piccolore": "^0.1.3", "picomatch": "^4.0.4", "rehype": "^13.0.2", "semver": "^7.7.4", "shiki": "^4.0.2", "smol-toml": "^1.6.0", "svgo": "^4.0.1", "tinyclip": "^0.1.12", "tinyexec": "^1.0.4", "tinyglobby": "^0.2.15", "ultrahtml": "^1.6.0", "unifont": "~0.7.4", "unist-util-visit": "^5.1.0", "unstorage": "^1.17.5", "vfile": "^6.0.3", "vite": "^7.3.2", "vitefu": "^1.1.2", "xxhash-wasm": "^1.1.0", "yargs-parser": "^22.0.0", "zod": "^4.3.6" }, "optionalDependencies": { "sharp": "^0.34.0" }, "bin": { "astro": "./bin/astro.mjs" } }, "sha512-5vsXx0H52u23Jpshs9tM81D03Tb3Oh2Vt2Zo0bpqjXN+njkAWjFyGjTfmWJLAcrCQd9Q+iWB1eqfhR1sZJEaUA=="],
+    "astro": ["astro@6.4.8", "", { "dependencies": { "@astrojs/compiler": "^4.0.0", "@astrojs/internal-helpers": "0.10.0", "@astrojs/markdown-remark": "7.2.0", "@astrojs/telemetry": "3.3.2", "@capsizecss/unpack": "^4.0.0", "@clack/prompts": "^1.1.0", "@oslojs/encoding": "^1.1.0", "@rollup/pluginutils": "^5.3.0", "aria-query": "^5.3.2", "axobject-query": "^4.1.0", "ci-info": "^4.4.0", "clsx": "^2.1.1", "common-ancestor-path": "^2.0.0", "cookie": "^1.1.1", "devalue": "^5.8.1", "diff": "^8.0.3", "dset": "^3.1.4", "es-module-lexer": "^2.0.0", "esbuild": "^0.27.3", "flattie": "^1.1.1", "fontace": "~0.4.1", "get-tsconfig": "5.0.0-beta.4", "github-slugger": "^2.0.0", "html-escaper": "3.0.3", "http-cache-semantics": "^4.2.0", "js-yaml": "^4.1.1", "jsonc-parser": "^3.3.1", "magic-string": "^0.30.21", "magicast": "^0.5.2", "mrmime": "^2.0.1", "neotraverse": "^0.6.18", "obug": "^2.1.1", "p-limit": "^7.3.0", "p-queue": "^9.1.0", "package-manager-detector": "^1.6.0", "piccolore": "^0.1.3", "picomatch": "^4.0.4", "rehype": "^13.0.2", "semver": "^7.7.4", "shiki": "^4.0.2", "smol-toml": "^1.6.0", "svgo": "^4.0.1", "tinyclip": "^0.1.12", "tinyexec": "^1.0.4", "tinyglobby": "^0.2.15", "ultrahtml": "^1.6.0", "unifont": "~0.7.4", "unist-util-visit": "^5.1.0", "unstorage": "^1.17.5", "vfile": "^6.0.3", "vite": "^7.3.2", "vitefu": "^1.1.2", "xxhash-wasm": "^1.1.0", "yargs-parser": "^22.0.0", "zod": "^4.3.6" }, "optionalDependencies": { "sharp": "^0.34.0" }, "bin": { "astro": "./bin/astro.mjs" } }, "sha512-KK5lX90uU9EeVaTjINyj3sy9/NFXVa59aowaqbWBDDKLXZh4rr7GwIaCFYVetE22MJtsCNFerQXn0vlCLmpP/Q=="],
 
     "astro-eslint-parser": ["astro-eslint-parser@1.4.0", "", { "dependencies": { "@astrojs/compiler": "^2.0.0 || ^3.0.0", "@typescript-eslint/scope-manager": "^7.0.0 || ^8.0.0", "@typescript-eslint/types": "^7.0.0 || ^8.0.0", "astrojs-compiler-sync": "^1.0.0", "debug": "^4.3.4", "entities": "^7.0.0", "eslint-scope": "^8.0.1", "eslint-visitor-keys": "^4.0.0", "espree": "^10.0.0", "fast-glob": "^3.3.3", "is-glob": "^4.0.3", "semver": "^7.3.8" } }, "sha512-+QDcgc7e+au6EZ0YjMmRRjNoQo5bDMlaR45aWDoFsuxQTCM9qmCHRoiKJPELgckJ8Wmr7vcfpa9eCDHBFh6G4w=="],
 
@@ -1054,7 +1052,7 @@
 
     "vscode-languageserver-textdocument": ["vscode-languageserver-textdocument@1.0.12", "", {}, "sha512-cxWNPesCnQCcMPeenjKKsOCKQZ/L6Tv19DTRIGuLWe32lyzWhihGVJ/rcckZXJxfdKCFvRLS3fpBIsV/ZGX4zA=="],
 
-    "vscode-languageserver-types": ["vscode-languageserver-types@3.17.5", "", {}, "sha512-Ld1VelNuX9pdF39h2Hgaeb5hEZM2Z3jUrrMgWQAu82jMtZp7p3vJT3BzToKtZI7NgQssZje5o0zryOrhQvzQAg=="],
+    "vscode-languageserver-types": ["vscode-languageserver-types@3.18.0", "", {}, "sha512-8TsGPNMIMiiBdkORgRSvLjuiEIiAFtO+KssmYWxQ+uSVvlf7RjK8YKCOjPzZ+YA04jXEV7+7LvkSmHkhpNS99g=="],
 
     "vscode-nls": ["vscode-nls@5.2.0", "", {}, "sha512-RAaHx7B14ZU04EU31pT+rKz2/zSl7xMsfIZuo8pd+KZO6PXtQmpevpq3vxvWNcrGbdmhM/rr5Uw5Mz+NBfhVng=="],
 
@@ -1088,6 +1086,8 @@
 
     "zwitch": ["zwitch@2.0.4", "", {}, "sha512-bXE4cR/kVZhKZX/RjPEflHaKVhUVl85noU3v6b8apfQEc1x4A+zBxjZ4lN8LqGd6WZ3dl98pY4o717VFmoPp+A=="],
 
+    "@astrojs/language-server/@astrojs/compiler": ["@astrojs/compiler@2.13.1", "", {}, "sha512-f3FN83d2G/v32ipNClRKgYv30onQlMZX1vCeZMjPsMMPl1mDpmbl0+N5BYo4S/ofzqJyS5hvwacEo0CCVDn/Qg=="],
+
     "@eslint-community/eslint-utils/eslint-visitor-keys": ["eslint-visitor-keys@3.4.3", "", {}, "sha512-wpc+LXeiyiisxPlEkUzU6svyS1frIO3Mgxj1fdy7Pm8Ygzguax2N3Fa/D/ag1WqbOprdI+uY6wMUl8/a2G+iag=="],
 
     "@tailwindcss/oxide-wasm32-wasi/@emnapi/core": ["@emnapi/core@1.11.1", "", { "dependencies": { "@emnapi/wasi-threads": "1.2.2", "tslib": "^2.4.0" }, "bundled": true }, "sha512-RSvbQmHzdKzNsLYa/wHrbc3KN4sYLKAdPZxqiM2HATqv/SBk2/ENSHpvXGaLOMcsAyz0poEGqkmmKYG3OWiJEQ=="],
@@ -1108,11 +1108,7 @@
 
     "anymatch/picomatch": ["picomatch@2.3.2", "", {}, "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA=="],
 
-    "astro/@astrojs/compiler": ["@astrojs/compiler@4.0.0", "", {}, "sha512-eouss7G8ygdZqHuke033VMcVw5HTZUu+PXd/h06DGDUg/jt5btPYPqh66ENWw/mU78rBrf/oeC4oqoBwMtDMNA=="],
-
-    "astro-eslint-parser/@typescript-eslint/scope-manager": ["@typescript-eslint/scope-manager@8.61.0", "", { "dependencies": { "@typescript-eslint/types": "8.61.0", "@typescript-eslint/visitor-keys": "8.61.0" } }, "sha512-IWdXFHFSb6mlC3HPc7QsLDm5zYEbUla6trDEHf32D3/dnuUyXd87plScSNXSbm0/RxMvObpI17sv/EDTGrGZkA=="],
-
-    "astro-eslint-parser/@typescript-eslint/types": ["@typescript-eslint/types@8.61.0", "", {}, "sha512-9QTQpZ5Iin4CdIodfbDQFSeiSJKidgYJYug1P9CC2xWgUTvlmixViqDZNciMjwLBZyJnG4tGmPl97rVAFb1AJg=="],
+    "astro-eslint-parser/@astrojs/compiler": ["@astrojs/compiler@3.0.1", "", {}, "sha512-z97oYbdebO5aoWzuJ/8q5hLK232+17KcLZ7cJ8BCWk6+qNzVxn/gftC0KzMBUTD8WAaBkPpNSQK6PXLnNrZ0CA=="],
 
     "csso/css-tree": ["css-tree@2.2.1", "", { "dependencies": { "mdn-data": "2.0.28", "source-map-js": "^1.0.1" } }, "sha512-OA0mILzGc1kCOCSJerOeqDxDQ4HOh+G8NbOJFOTgOCzpw7fCBubk0fEyxp8AgOL/jvLgYA/uV0cMbe43ElF1JA=="],
 
@@ -1125,8 +1121,6 @@
     "eslint/espree": ["espree@11.2.0", "", { "dependencies": { "acorn": "^8.16.0", "acorn-jsx": "^5.3.2", "eslint-visitor-keys": "^5.0.1" } }, "sha512-7p3DrVEIopW1B1avAGLuCSh1jubc01H2JHc8B4qqGblmg5gI9yumBgACjWo4JlIc04ufug4xJ3SQI8HkS/Rgzw=="],
 
     "eslint/ignore": ["ignore@5.3.2", "", {}, "sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g=="],
-
-    "eslint-plugin-astro/@typescript-eslint/types": ["@typescript-eslint/types@8.61.0", "", {}, "sha512-9QTQpZ5Iin4CdIodfbDQFSeiSJKidgYJYug1P9CC2xWgUTvlmixViqDZNciMjwLBZyJnG4tGmPl97rVAFb1AJg=="],
 
     "eslint-plugin-astro/globals": ["globals@16.5.0", "", {}, "sha512-c/c15i26VrJ4IRt5Z89DnIzCGDn9EcebibhAOjw5ibqEHsE1wLUgkPn9RDmNcUKyU87GeaL633nyJ+pplFR2ZQ=="],
 
@@ -1142,15 +1136,17 @@
 
     "parse5/entities": ["entities@6.0.1", "", {}, "sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g=="],
 
+    "prettier-plugin-astro/@astrojs/compiler": ["@astrojs/compiler@2.13.1", "", {}, "sha512-f3FN83d2G/v32ipNClRKgYv30onQlMZX1vCeZMjPsMMPl1mDpmbl0+N5BYo4S/ofzqJyS5hvwacEo0CCVDn/Qg=="],
+
     "rollup/fsevents": ["fsevents@2.3.3", "", { "os": "darwin" }, "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw=="],
 
     "unstorage/chokidar": ["chokidar@5.0.0", "", { "dependencies": { "readdirp": "^5.0.0" } }, "sha512-TQMmc3w+5AxjpL8iIiwebF73dRDF4fBIieAqGn9RGCWaEVwQ6Fb2cGe31Yns0RRIzii5goJ1Y7xbMwo1TxMplw=="],
 
     "vite/fsevents": ["fsevents@2.3.3", "", { "os": "darwin" }, "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw=="],
 
-    "vscode-languageserver/vscode-languageserver-protocol": ["vscode-languageserver-protocol@3.17.5", "", { "dependencies": { "vscode-jsonrpc": "8.2.0", "vscode-languageserver-types": "3.17.5" } }, "sha512-mb1bvRJN8SVznADSGWM9u/b07H7Ecg0I3OgXDuLdn307rl/J3A9YD6/eYOssqhecL27hK1IPZAsaqh00i/Jljg=="],
+    "vscode-css-languageservice/vscode-languageserver-types": ["vscode-languageserver-types@3.17.5", "", {}, "sha512-Ld1VelNuX9pdF39h2Hgaeb5hEZM2Z3jUrrMgWQAu82jMtZp7p3vJT3BzToKtZI7NgQssZje5o0zryOrhQvzQAg=="],
 
-    "vscode-languageserver-protocol/vscode-languageserver-types": ["vscode-languageserver-types@3.18.0", "", {}, "sha512-8TsGPNMIMiiBdkORgRSvLjuiEIiAFtO+KssmYWxQ+uSVvlf7RjK8YKCOjPzZ+YA04jXEV7+7LvkSmHkhpNS99g=="],
+    "vscode-languageserver/vscode-languageserver-protocol": ["vscode-languageserver-protocol@3.17.5", "", { "dependencies": { "vscode-jsonrpc": "8.2.0", "vscode-languageserver-types": "3.17.5" } }, "sha512-mb1bvRJN8SVznADSGWM9u/b07H7Ecg0I3OgXDuLdn307rl/J3A9YD6/eYOssqhecL27hK1IPZAsaqh00i/Jljg=="],
 
     "yaml-language-server/ajv": ["ajv@8.20.0", "", { "dependencies": { "fast-deep-equal": "^3.1.3", "fast-uri": "^3.0.1", "json-schema-traverse": "^1.0.0", "require-from-string": "^2.0.2" } }, "sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA=="],
 
@@ -1160,16 +1156,14 @@
 
     "yargs/yargs-parser": ["yargs-parser@21.1.1", "", {}, "sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw=="],
 
-    "astro-eslint-parser/@typescript-eslint/scope-manager/@typescript-eslint/visitor-keys": ["@typescript-eslint/visitor-keys@8.61.0", "", { "dependencies": { "@typescript-eslint/types": "8.61.0", "eslint-visitor-keys": "^5.0.0" } }, "sha512-QVLZu3ZPQEE+HICQyAMZ2yLQhxf0meY/wx6Hx14YcTNj13JB3qHlX3lJ02L3fLGHgERRH71kvYDwiXIguT3AjQ=="],
-
     "csso/css-tree/mdn-data": ["mdn-data@2.0.28", "", {}, "sha512-aylIc7Z9y4yzHYAJNuESG3hfhC+0Ibp/MAMiaOZgNv4pmEdFyfZhhhny4MNiAfWdBQ1RQ2mfDWmM1x8SvGyp8g=="],
 
     "unstorage/chokidar/readdirp": ["readdirp@5.0.0", "", {}, "sha512-9u/XQ1pvrQtYyMpZe7DXKv2p5CNvyVwzUB6uhLAnQwHMSgKMBR62lc7AHljaeteeHXn11XTAaLLUVZYVZyuRBQ=="],
 
     "vscode-languageserver/vscode-languageserver-protocol/vscode-jsonrpc": ["vscode-jsonrpc@8.2.0", "", {}, "sha512-C+r0eKJUIfiDIfwJhria30+TYWPtuHJXHtI7J0YlOmKAo7ogxP20T0zxB7HZQIFhIyvoBPwWskjxrvAtfjyZfA=="],
 
-    "yaml-language-server/ajv/json-schema-traverse": ["json-schema-traverse@1.0.0", "", {}, "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug=="],
+    "vscode-languageserver/vscode-languageserver-protocol/vscode-languageserver-types": ["vscode-languageserver-types@3.17.5", "", {}, "sha512-Ld1VelNuX9pdF39h2Hgaeb5hEZM2Z3jUrrMgWQAu82jMtZp7p3vJT3BzToKtZI7NgQssZje5o0zryOrhQvzQAg=="],
 
-    "astro-eslint-parser/@typescript-eslint/scope-manager/@typescript-eslint/visitor-keys/eslint-visitor-keys": ["eslint-visitor-keys@5.0.1", "", {}, "sha512-tD40eHxA35h0PEIZNeIjkHoDR4YjjJp34biM0mDvplBe//mB+IHCqHDGV7pxF+7MklTvighcCPPZC7ynWyjdTA=="],
+    "yaml-language-server/ajv/json-schema-traverse": ["json-schema-traverse@1.0.0", "", {}, "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug=="],
   }
 }

--- a/e2e/album-collage.spec.ts
+++ b/e2e/album-collage.spec.ts
@@ -20,6 +20,8 @@ const openBooklet = async (page: Page) => {
   await expect(page.locator("#booklet")).toBeVisible();
 };
 
+const getPathname = (page: Page) => new URL(page.url()).pathname;
+
 test.describe("Render Mix collage", () => {
   test("loads the landing video and opens the collage", async ({ page }) => {
     await page.goto("/");
@@ -166,6 +168,70 @@ test.describe("Render Mix collage", () => {
     await expect(page.locator("#overlay-description")).toHaveText(firstEpisode.description);
     await expect(page.locator("#overlay-tracks .track-row")).toHaveCount(firstEpisode.tracks.length);
     await expect(page.locator("#overlay-player iframe")).toHaveAttribute("src", /mixcloud\.com/);
+  });
+
+  test("opens an episode overlay from a direct deep link", async ({ page }) => {
+    await page.goto("/episodes/ah001");
+
+    const episodes = await getEpisodes(page);
+    const episode = episodes.find(({ id }) => id === "ah001");
+
+    expect(episode).toBeTruthy();
+    await expect(page.locator("#landing")).toBeHidden();
+    await expect(page.locator("#booklet")).toBeVisible();
+    await expect(page.locator("#mix-overlay")).toHaveAttribute("aria-hidden", "false");
+    await expect(page.locator("#overlay-title")).toHaveText(episode?.title || "");
+    await expect(page).toHaveTitle(`${episode?.title} | The Invigilators`);
+    await expect(page.locator('link[rel="canonical"]')).toHaveAttribute("href", /\/episodes\/ah001$/);
+    await expect(page.locator('meta[property="og:image"]')).toHaveAttribute("content", /\/img\/episode-/);
+  });
+
+  test("updates the URL when opening and closing an episode", async ({ page }) => {
+    await openBooklet(page);
+
+    const [firstEpisode] = await getEpisodes(page);
+    await page.locator(".album-tile").first().click();
+
+    await expect(page.locator("#mix-overlay")).toHaveAttribute("aria-hidden", "false");
+    expect(getPathname(page)).toBe(`/episodes/${firstEpisode.id}`);
+
+    await page.locator("#overlay-close").click();
+    await expect(page.locator("#mix-overlay")).toHaveAttribute("aria-hidden", "true");
+    expect(getPathname(page)).toBe("/");
+  });
+
+  test("keeps the deep link current while navigating overlay albums", async ({ page }) => {
+    await openBooklet(page);
+
+    const episodes = await getEpisodes(page);
+    await page.locator(".album-tile").first().click();
+    await expect(page.locator("#mix-overlay")).toHaveAttribute("aria-hidden", "false");
+
+    await page.locator("#overlay-next").click();
+    await expect(page.locator("#overlay-title")).toHaveText(episodes[1].title);
+    expect(getPathname(page)).toBe(`/episodes/${episodes[1].id}`);
+
+    await page.locator("#overlay-prev").click();
+    await expect(page.locator("#overlay-title")).toHaveText(episodes[0].title);
+    expect(getPathname(page)).toBe(`/episodes/${episodes[0].id}`);
+  });
+
+  test("handles browser back and forward for episode overlays", async ({ page }) => {
+    await openBooklet(page);
+
+    const [firstEpisode] = await getEpisodes(page);
+    await page.locator(".album-tile").first().click();
+    await expect(page.locator("#mix-overlay")).toHaveAttribute("aria-hidden", "false");
+    expect(getPathname(page)).toBe(`/episodes/${firstEpisode.id}`);
+
+    await page.goBack();
+    await expect(page.locator("#mix-overlay")).toHaveAttribute("aria-hidden", "true");
+    expect(getPathname(page)).toBe("/");
+
+    await page.goForward();
+    await expect(page.locator("#mix-overlay")).toHaveAttribute("aria-hidden", "false");
+    await expect(page.locator("#overlay-title")).toHaveText(firstEpisode.title);
+    expect(getPathname(page)).toBe(`/episodes/${firstEpisode.id}`);
   });
 
   test("uses the selected album background behind the tracklist", async ({ page }) => {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "invigilators",
   "type": "module",
-  "version": "1.1.1",
+  "version": "1.2.1",
   "scripts": {
     "dev": "astro dev",
     "start": "astro dev",
@@ -13,17 +13,14 @@
     "typecheck": "tsc --noEmit",
     "format": "prettier --write src/**/*.{astro,js,ts,json,css}"
   },
-  "dependencies": {
-    "@astrojs/check": "^0.9.9",
-    "astro": "^6.4.6",
-    "typescript": "^6"
-  },
   "devDependencies": {
+    "@astrojs/check": "^0.9.9",
     "@tailwindcss/vite": "^4.3.1",
     "@playwright/test": "^1.61.0",
     "@types/node": "^25",
     "@typescript-eslint/eslint-plugin": "^8.61.1",
     "@typescript-eslint/parser": "^8.61.1",
+    "astro": "^6.4.8",
     "astro-eslint-parser": "^1.4.0",
     "eslint": "^10",
     "eslint-config-prettier": "^10",
@@ -31,7 +28,8 @@
     "globals": "^17",
     "prettier": "^3",
     "prettier-plugin-astro": "^0.14.1",
-    "tailwindcss": "^4"
+    "tailwindcss": "^4",
+    "typescript": "^6"
   },
   "overrides": {
     "yocto-queue": "0.1.0"

--- a/src/components/Episode.astro
+++ b/src/components/Episode.astro
@@ -16,12 +16,12 @@ const fallbackImage = image_bg || "/img/episode-bg/ahNotFound.png";
 const typeLabel = type === "mykonos" ? "Mykonos Sessions" : "Aural Homework";
 ---
 
-<button
+<a
+  href={`/episodes/${id}`}
   class="album-tile group relative block aspect-square w-full origin-center cursor-pointer overflow-hidden border-0 bg-black p-0 text-(--foreground) transition-[transform,box-shadow] duration-320 ease-[cubic-bezier(0.22,1,0.36,1)] transform-gpu will-change-transform backface-hidden hover:z-5 hover:scale-[1.08] hover:shadow-[0_16px_40px_rgba(0,0,0,0.5),0_0_0_1px_rgba(240,228,228,0.22)] focus-visible:z-4 focus-visible:outline-2 focus-visible:-outline-offset-2 focus-visible:outline-[rgba(255,255,255,0.86)] hover:focus-visible:z-5"
   data-id={id}
   data-index={index}
   data-type={type}
-  type="button"
   aria-label={`Open ${title}`}
 >
   <img
@@ -51,4 +51,4 @@ const typeLabel = type === "mykonos" ? "Mykonos Sessions" : "Aural Homework";
   <span
     class="album-tile-border pointer-events-none absolute inset-0 border border-[rgba(240,228,228,0)] transition-colors duration-120 group-hover:border-[rgba(240,228,228,0.38)] group-focus-visible:border-[rgba(240,228,228,0.38)]"
     aria-hidden="true"></span>
-</button>
+</a>

--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -4,12 +4,20 @@ import "../styles/global.css";
 interface Props {
   title: string;
   description?: string;
+  canonicalPath?: string;
+  image?: string;
 }
 
 const {
   title,
   description = "Trance and progressive music mixers who create and upload dj sets from time to time.",
+  canonicalPath = "/",
+  image,
 } = Astro.props;
+
+const siteUrl = "https://www.theinvigilators.com";
+const canonicalUrl = new URL(canonicalPath, siteUrl).toString();
+const imageUrl = image ? new URL(image, siteUrl).toString() : undefined;
 ---
 
 <!doctype html>
@@ -19,20 +27,23 @@ const {
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <meta name="description" content={description} />
     <meta name="generator" content={Astro.generator} />
+    <link rel="canonical" href={canonicalUrl} />
 
     <!-- Twitter Card data -->
-    <meta property="twitter:card" content="summary" />
-    <meta property="twitter:url" content="https://www.theinvigilators.com/" />
+    <meta property="twitter:card" content={imageUrl ? "summary_large_image" : "summary"} />
+    <meta property="twitter:url" content={canonicalUrl} />
     <meta property="twitter:title" content={`${title}`} />
     <meta property="twitter:description" content={description} />
     <meta property="twitter:site" content="@theinvigilators" />
+    {imageUrl && <meta property="twitter:image" content={imageUrl} />}
 
     <!-- Open Graph data -->
     <meta property="og:type" content="website" />
-    <meta property="og:url" content="https://www.theinvigilators.com/" />
+    <meta property="og:url" content={canonicalUrl} />
     <meta property="og:title" content={`${title}`} />
     <meta property="og:description" content={description} />
     <meta property="og:site_name" content="The Invigilators" />
+    {imageUrl && <meta property="og:image" content={imageUrl} />}
     <meta property="fb:app_id" content="627980390669845" />
 
     <!-- Favicons -->
@@ -43,7 +54,7 @@ const {
     <meta name="theme-color" content="#dc143c" />
 
     <!-- Google Analytics -->
-    <script async src="https://www.googletagmanager.com/gtag/js?id=G-ZQ0PNZ57Y4"></script>
+    <script defer src="https://www.googletagmanager.com/gtag/js?id=G-ZQ0PNZ57Y4"></script>
     <script defer>
       window.dataLayer = window.dataLayer || [];
       function gtag() {

--- a/src/pages/episodes/[id].astro
+++ b/src/pages/episodes/[id].astro
@@ -1,0 +1,42 @@
+---
+import Layout from "../../layouts/Layout.astro";
+import Hero from "../../components/Hero.astro";
+import EpisodesList from "../../components/EpisodesList.astro";
+import { getEpisodes } from "../../services/episodes";
+
+export async function getStaticPaths() {
+  const episodes = await getEpisodes();
+
+  return episodes.map((episode) => ({
+    params: { id: episode.id },
+    props: { episode, episodes },
+  }));
+}
+
+const { episode, episodes } = Astro.props;
+const initialEpisodeId = episode.id;
+const episodeImage = episode.image_cover || episode.image_bg;
+---
+
+<Layout
+  title={`${episode.title} | The Invigilators`}
+  description={episode.description}
+  canonicalPath={`/episodes/${episode.id}`}
+  image={episodeImage}
+>
+  <Hero />
+  <EpisodesList allEpisodes={episodes} />
+</Layout>
+
+<script define:vars={{ episodes, initialEpisodeId }}>
+  window.episodes = episodes;
+  window.initialEpisodeId = initialEpisodeId;
+</script>
+
+<script>
+  import { initApp } from "../../scripts/app";
+
+  document.addEventListener("DOMContentLoaded", () => {
+    initApp();
+  });
+</script>

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -5,6 +5,7 @@ import EpisodesList from "../components/EpisodesList.astro";
 import { getEpisodes } from "../services/episodes";
 
 const episodes = await getEpisodes();
+const initialEpisodeId = null;
 ---
 
 <Layout title="The Invigilators">
@@ -12,8 +13,9 @@ const episodes = await getEpisodes();
   <EpisodesList allEpisodes={episodes} />
 </Layout>
 
-<script define:vars={{ episodes }}>
+<script define:vars={{ episodes, initialEpisodeId }}>
   window.episodes = episodes;
+  window.initialEpisodeId = initialEpisodeId;
 </script>
 
 <script>

--- a/src/scripts/app.ts
+++ b/src/scripts/app.ts
@@ -3,6 +3,7 @@ import type { Episode } from "../services/episodes";
 declare global {
   interface Window {
     episodes: Episode[];
+    initialEpisodeId?: string | null;
   }
 }
 
@@ -42,6 +43,7 @@ const initLandingVideo = () => {
 };
 
 const OVERLAY_TRANSITION_MS = 280;
+const EPISODE_ROUTE_PATTERN = /^\/episodes\/([^/]+?)(?:\.html)?\/?$/;
 
 const initTileImageFallbacks = () => {
   document.querySelectorAll<HTMLImageElement>(".album-tile img").forEach((image) => {
@@ -63,15 +65,23 @@ const initEnterButton = () => {
 
   if (enterBtn && landing && booklet) {
     enterBtn.addEventListener("click", () => {
-      landing.classList.add("is-exiting");
-      window.setTimeout(() => {
-        landing.classList.add("hidden");
-        booklet.classList.remove("hidden");
-        booklet.classList.add("is-visible");
-        document.querySelector<HTMLElement>(".album-tile")?.focus();
-      }, 260);
+      showBooklet(true);
     });
   }
+};
+
+const showBooklet = (focusFirstTile = false) => {
+  const landing = document.getElementById("landing");
+  const booklet = document.getElementById("booklet");
+  if (!landing || !booklet) return;
+
+  landing.classList.add("is-exiting");
+  window.setTimeout(() => {
+    landing.classList.add("hidden");
+    booklet.classList.remove("hidden");
+    booklet.classList.add("is-visible");
+    if (focusFirstTile) document.querySelector<HTMLElement>(".album-tile")?.focus();
+  }, 260);
 };
 
 const getEpisodeImage = (episode: Episode) => {
@@ -109,6 +119,17 @@ const renderPlayer = (container: HTMLElement, mixcloud: string, title: string) =
       loading="lazy"
     ></iframe>
   `;
+};
+
+const getEpisodePath = (episode: Episode) => `/episodes/${episode.id}`;
+
+const getEpisodeIdFromPath = () => {
+  const match = window.location.pathname.match(EPISODE_ROUTE_PATTERN);
+  return match ? decodeURIComponent(match[1]) : null;
+};
+
+const shouldHandleTileClick = (event: MouseEvent) => {
+  return event.button === 0 && !event.metaKey && !event.ctrlKey && !event.shiftKey && !event.altKey;
 };
 
 const initAlbumOverlay = () => {
@@ -152,11 +173,14 @@ const initAlbumOverlay = () => {
     return;
   }
 
-  const closeOverlay = () => {
+  const closeOverlay = (updateUrl = true) => {
     const tile = document.querySelector<HTMLElement>(`.album-tile[data-index="${currentIndex}"]`);
     overlay.classList.remove("is-open");
     overlay.setAttribute("aria-hidden", "true");
     document.body.classList.remove("overlay-open");
+    if (updateUrl && window.location.pathname !== "/") {
+      window.history.replaceState({ episodeId: null }, "", "/");
+    }
     window.clearTimeout(closeTimer);
     closeTimer = window.setTimeout(() => {
       overlay.classList.add("hidden");
@@ -165,7 +189,7 @@ const initAlbumOverlay = () => {
     }, OVERLAY_TRANSITION_MS);
   };
 
-  const openOverlay = (episode: Episode, index: number) => {
+  const openOverlay = (episode: Episode, index: number, updateUrl: false | "push" | "replace" = false) => {
     currentIndex = index;
     image.src = getEpisodeImage(episode);
     image.alt = episode.title;
@@ -196,6 +220,13 @@ const initAlbumOverlay = () => {
 
     player.innerHTML = "";
     renderPlayer(player, episode.mixcloud, episode.title);
+    if (updateUrl) {
+      window.history[updateUrl === "push" ? "pushState" : "replaceState"](
+        { episodeId: episode.id },
+        "",
+        getEpisodePath(episode)
+      );
+    }
     window.clearTimeout(closeTimer);
     overlay.classList.remove("hidden");
     overlay.setAttribute("aria-hidden", "false");
@@ -204,28 +235,49 @@ const initAlbumOverlay = () => {
     closeButton.focus();
   };
 
-  const openByIndex = (index: number) => {
+  const openByIndex = (index: number, updateUrl: false | "push" | "replace" = false) => {
     const episode = window.episodes[index];
-    if (episode) openOverlay(episode, index);
+    if (episode) openOverlay(episode, index, updateUrl);
+  };
+
+  const openById = (episodeId: string | null, updateUrl: false | "push" | "replace" = false) => {
+    if (!episodeId) return;
+    const index = window.episodes.findIndex((episode) => episode.id === episodeId);
+    if (index >= 0) {
+      showBooklet(false);
+      openByIndex(index, updateUrl);
+    }
   };
 
   document.querySelectorAll(".album-tile").forEach((tile) => {
-    tile.addEventListener("click", () => {
+    tile.addEventListener("click", (event) => {
+      if (!shouldHandleTileClick(event as MouseEvent)) return;
+      event.preventDefault();
       const index = Number((tile as HTMLElement).dataset.index);
-      openByIndex(index);
+      openByIndex(index, "push");
     });
   });
 
-  closeButton.addEventListener("click", closeOverlay);
-  prevButton.addEventListener("click", () => openByIndex(currentIndex - 1));
-  nextButton.addEventListener("click", () => openByIndex(currentIndex + 1));
+  closeButton.addEventListener("click", () => closeOverlay());
+  prevButton.addEventListener("click", () => openByIndex(currentIndex - 1, "replace"));
+  nextButton.addEventListener("click", () => openByIndex(currentIndex + 1, "replace"));
   overlay.addEventListener("click", (event) => {
     if (event.target === overlay) closeOverlay();
   });
   document.addEventListener("keydown", (event) => {
     if (!overlay.classList.contains("is-open")) return;
     if (event.key === "Escape") closeOverlay();
-    if (event.key === "ArrowLeft") openByIndex(currentIndex - 1);
-    if (event.key === "ArrowRight") openByIndex(currentIndex + 1);
+    if (event.key === "ArrowLeft") openByIndex(currentIndex - 1, "replace");
+    if (event.key === "ArrowRight") openByIndex(currentIndex + 1, "replace");
   });
+  window.addEventListener("popstate", () => {
+    const episodeId = getEpisodeIdFromPath();
+    if (episodeId) {
+      openById(episodeId);
+    } else {
+      closeOverlay(false);
+    }
+  });
+
+  openById(window.initialEpisodeId || getEpisodeIdFromPath());
 };


### PR DESCRIPTION
## Summary
- add static episode routes at `/episodes/:id` for shareable deep links
- open the existing episode overlay from direct route loads and keep browser history in sync while opening, closing, and navigating episodes
- add episode-specific canonical, Open Graph, and Twitter metadata
- switch Astro output to directory format so GitHub Pages can serve extensionless episode URLs
- move static-site build tooling into `devDependencies` and simplify the Bun deploy workflow

## Testing
- `bun run typecheck`
- `bun run build`
- added Playwright coverage for direct deep links, URL updates, overlay navigation, and browser back/forward behavior

## Notes
- Episode URLs are canonicalized without `.html`, e.g. `/episodes/ah001`.
- The route parser still accepts `.html` episode paths as a fallback.